### PR TITLE
Add installation script confirmations & sanitize shell input

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ My personal Neovim configuration setup for DevOps & Coding
 ### Prerequisites
 
 - [Neovim](https://neovim.io/) (version 0.10 or higher)
-    - nvim-install.sh installs the latest Neovim version
+    - nvim-install.sh installs the latest Neovim version (Run as `. nvim-install.sh` so that it's sourced in the current shell and not a subshell)
 - [Git](https://git-scm.com/)
 
 ### Steps

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -21,8 +21,9 @@ map('n', '<leader>sq', ':term lazysql<CR>i', default_opts)
 -- Map <leader>po to run 'posting --collection <posting-collection-path>'
 map('n', '<leader>po', function()
   vim.ui.input({ prompt = 'Enter posting collection path: ' }, function(input)
-    if input ~= nil and input ~= '' then
-      vim.cmd('term posting --collection ' .. input)
+    if input and input ~= '' then
+      local safe_input = vim.fn.shellescape(input)
+      vim.cmd('term posting --collection ' .. safe_input)
     else
       vim.cmd('term posting')
     end

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Exit immediately if a command exits with a non-zero status
 set -e
 
@@ -11,30 +10,37 @@ BIN_DIR="$INSTALL_DIR/bin"
 # Determine the directory where the script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Download the latest Neovim release
-curl -LO "$NVIM_URL" 
+echo "Downloading Neovim from ${NVIM_URL}..."
+curl -LO "$NVIM_URL"
 
-# Remove any existing Neovim installation
+echo
+echo "WARNING: This script will remove any existing Neovim installations located at /opt/nvim and ${INSTALL_DIR}."
+read -p "Do you wish to continue? [y/N] " confirmation
+if [[ ! "$confirmation" =~ ^[Yy]$ ]]; then
+  echo "Installation cancelled."
+  exit 1
+fi
+
+echo "Removing existing Neovim installations..."
 sudo rm -rf /opt/nvim
 sudo rm -rf "$INSTALL_DIR"
 
-# Extract the downloaded archive to /opt
-sudo tar -C /opt -xzf "$NVIM_ARCHIVE" 
+echo "Extracting the downloaded archive to /opt..."
+sudo tar -C /opt -xzf "$NVIM_ARCHIVE"
 
-# Remove the downloaded archive to clean up
+echo "Cleaning up the downloaded archive..."
 rm "$NVIM_ARCHIVE"
 
 # Add Neovim to the PATH in ~/.bashrc if it's not already there
 if ! grep -q "$BIN_DIR" ~/.bashrc; then
-    echo 'export PATH="$PATH:/opt/nvim-linux64/bin"' >> ~/.bashrc
+    echo "export PATH=\"\$PATH:${BIN_DIR}\"" >> ~/.bashrc
     echo "Added Neovim to PATH in ~/.bashrc"
 else
     echo "Neovim path already exists in ~/.bashrc"
 fi
 
-# Because of how scripts are executed in a subshell, this will not propagate to
-# the parent shell unless its explicitly specified to run the script in the current shell
-# e.g. source <script.sh> or . <script.sh>
+# Source ~/.bashrc to update the PATH for the current session
+# (Note: This may not propagate to the parent shell.)
 source ~/.bashrc
 
 # Verify Neovim installation
@@ -45,16 +51,12 @@ else
     exit 1
 fi
 
-# Move the 'nvim' directory from the script's directory to ~/.config
+# Move the 'nvim' directory from the script's directory to ~/.config if it exists
 NVIM_CONFIG_SOURCE="$SCRIPT_DIR"
 NVIM_CONFIG_DEST="$HOME/.config/nvim"
 
-# Check if the source directory exists
 if [ -d "$NVIM_CONFIG_SOURCE" ]; then
-    # Create the destination directory if it doesn't exist
     mkdir -p "$(dirname "$NVIM_CONFIG_DEST")"
-    
-    # Move the nvim directory
     mv "$NVIM_CONFIG_SOURCE" "$NVIM_CONFIG_DEST"
     echo "Moved 'nvim' configuration to ~/.config/nvim"
 else

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -2,9 +2,9 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-NVIM_URL="https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz"
-NVIM_ARCHIVE="nvim-linux64.tar.gz"
-INSTALL_DIR="/opt/nvim-linux64"
+NVIM_URL="https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz"
+NVIM_ARCHIVE="nvim-linux-x86_64.tar.gz"
+INSTALL_DIR="/opt/nvim-linux-x86_64"
 BIN_DIR="$INSTALL_DIR/bin"
 
 # Determine the directory where the script is located


### PR DESCRIPTION
## Description
Introduces:
- Confirmation prompts before performing destructive operations in the installation script
- Input sanitization to prevent potential shell injection when running shell commands from within Neovim

Previously, the installation script (`nvim-install.sh`) automatically removed existing Neovim installations without confirmation, which could lead to accidental data loss and leaves users in the dark as to file manipulations are happening in the background.

Additionally, user input was concatenated directly into shell commands in mappings, posing a minor risk of shell injection. Even if it is being executed by users themselves in their own local environments, the goal is to adhere to security best practices consistently across the codebase.

## Related Issue(s)
n/a

## Changes Made
- Added script caution prompts before performing destructive actions like `rm -rf /opt/nvim`
- Implemented user input sanitization in `lua/mappings.lua` to prevent shell injection in terminal commands

## Type of Change
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📄 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🛠 Maintenance
- [x] 🔒 Security fix
